### PR TITLE
Added a validator dispatcher with two POC tests

### DIFF
--- a/CtrlVAF/CtrlVAF.Commands/Dispatcher.cs
+++ b/CtrlVAF/CtrlVAF.Commands/Dispatcher.cs
@@ -18,7 +18,13 @@ namespace CtrlVAF.Commands
 
             var executingAssembly = Assembly.GetCallingAssembly();
             var types = executingAssembly.GetTypes();
-            Type[] concreteTypes = types.Where(t => t.IsClass && t.GetInterfaces().Contains(handlerType)).ToArray();
+
+            Type[] concreteTypes = types.Where(
+                t => 
+                    t.IsClass && 
+                    t.GetInterfaces().Contains(handlerType)
+                    )
+                .ToArray();
 
             if (!concreteTypes.Any()) return;
 

--- a/CtrlVAF/CtrlVAF.Tests/CommandTests/CommandTests.cs
+++ b/CtrlVAF/CtrlVAF.Tests/CommandTests/CommandTests.cs
@@ -19,7 +19,8 @@ namespace CtrlVAF.Tests.CommandTests
             var environment = new EventHandlerEnvironment();
 
             var dispatcher = new Dispatcher();
-            dispatcher.Dispatch(new BeforeSetPropertiesCommand<Configuration>() { Env = environment, Configuration = conf });
+            var command = new BeforeSetPropertiesCommand<Configuration>() { Env = environment, Configuration = conf };
+            dispatcher.Dispatch(command);
 
             Assert.AreEqual(expected, environment.CurrentUserID);
         }

--- a/CtrlVAF/CtrlVAF.Tests/CommandTests/CreateCustomerHandler.cs
+++ b/CtrlVAF/CtrlVAF.Tests/CommandTests/CreateCustomerHandler.cs
@@ -12,7 +12,7 @@ namespace CtrlVAF.Tests.CommandTests
     {
         public void Handle(BeforeSetPropertiesCommand<Configuration> command)
         {
-            throw new NotImplementedException();
+            return;
         }
     }
 }

--- a/CtrlVAF/CtrlVAF.Tests/ConfigValidationTests/Child_ConfigurationValidator.cs
+++ b/CtrlVAF/CtrlVAF.Tests/ConfigValidationTests/Child_ConfigurationValidator.cs
@@ -1,0 +1,27 @@
+﻿using CtrlVAF.Validators;
+
+using MFiles.VAF.Configuration;
+
+using MFilesAPI;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace CtrlVAF.Tests.ConfigValidationTests
+{
+    class Child_ConfigurationValidator: CustomValidator<Child_Configuration>
+    {
+        protected override IEnumerable<ValidationFinding> Validate(Vault vault, Child_Configuration configuration)
+        {
+            if (string.IsNullOrWhiteSpace(configuration.Name))
+                yield return new ValidationFinding(
+                    ValidationFindingType.Error,
+                    "Name",
+                    "No Value"
+                    );
+        }
+    }
+}

--- a/CtrlVAF/CtrlVAF.Tests/ConfigValidationTests/ConfigValidationTests.cs
+++ b/CtrlVAF/CtrlVAF.Tests/ConfigValidationTests/ConfigValidationTests.cs
@@ -1,0 +1,50 @@
+﻿using CtrlVAF.Validators;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using System;
+using System.Linq;
+
+namespace CtrlVAF.Tests.ConfigValidationTests
+{
+    [TestClass]
+    public class ConfigValidationTests
+    {
+        [TestMethod]
+        public void Assert_BaseCase()
+        {
+            var expected = 1;
+
+            var dispatcher = new Dispatcher();
+
+            //Runs ICustomValidator.Validate(vault, config) on all classes that implement CustomValidator<T> 
+            //where T is the configuration class or a class used by it's members.
+            var results = dispatcher.Dispatch(new MFilesAPI.Vault(), new Configuration {Name = "", ID = 42 });
+
+            Assert.AreEqual(expected, results.Count());
+        }
+
+        [TestMethod]
+        public void Assert_ChildConfiguration()
+        {
+            var expected = 1;
+
+            Configuration config = new Configuration
+            {
+                Name = "name",
+                ID = 42,
+                ChildConfig = new Child_Configuration
+                {
+                    Name = ""
+                }
+            };
+
+            Dispatcher dispatcher = new Dispatcher();
+
+            var results = dispatcher.Dispatch(new MFilesAPI.Vault(), config);
+
+            Assert.AreEqual(expected, results.Count());
+
+        }
+    }
+}

--- a/CtrlVAF/CtrlVAF.Tests/ConfigValidationTests/Configuration.cs
+++ b/CtrlVAF/CtrlVAF.Tests/ConfigValidationTests/Configuration.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace CtrlVAF.Tests.ConfigValidationTests
+{
+    class Configuration
+    {
+        public string Name { get; set; }
+        public int ID { get; set; }
+
+        public Child_Configuration ChildConfig { get; set; }
+    }
+
+    class Child_Configuration
+    {
+        public string Name { get; set; }
+    }
+}

--- a/CtrlVAF/CtrlVAF.Tests/ConfigValidationTests/ConfigurationValidator.cs
+++ b/CtrlVAF/CtrlVAF.Tests/ConfigValidationTests/ConfigurationValidator.cs
@@ -1,0 +1,34 @@
+﻿using CtrlVAF.Validators;
+
+using MFiles.VAF.Configuration;
+
+using MFilesAPI;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace CtrlVAF.Tests.ConfigValidationTests
+{
+    class ConfigurationValidator : CustomValidator<Configuration>
+    {
+        protected override IEnumerable<ValidationFinding> Validate(Vault vault, Configuration configuration)
+        {
+            if (string.IsNullOrWhiteSpace(configuration.Name))
+                yield return new ValidationFinding(
+                    ValidationFindingType.Error,
+                    "Name",
+                    "No Value"
+                    );
+
+            if (configuration.ID == -1)
+                yield return new ValidationFinding(
+                    ValidationFindingType.Error,
+                    "ID",
+                    "Not Found"
+                    );
+        }
+    }
+}

--- a/CtrlVAF/CtrlVAF.Tests/CtrlVAF.Tests.csproj
+++ b/CtrlVAF/CtrlVAF.Tests/CtrlVAF.Tests.csproj
@@ -84,6 +84,10 @@
     <Compile Include="CommandTests\CommandTests.cs" />
     <Compile Include="CommandTests\Configuration.cs" />
     <Compile Include="CommandTests\CreateCustomerHandler.cs" />
+    <Compile Include="ConfigValidationTests\Child_ConfigurationValidator.cs" />
+    <Compile Include="ConfigValidationTests\Configuration.cs" />
+    <Compile Include="ConfigValidationTests\ConfigurationValidator.cs" />
+    <Compile Include="ConfigValidationTests\ConfigValidationTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
@@ -93,6 +97,10 @@
     <ProjectReference Include="..\CtrlVAF.Commands\CtrlVAF.Commands.csproj">
       <Project>{a473ed6c-0e80-4bcc-a07f-359c36313565}</Project>
       <Name>CtrlVAF.Commands</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\CtrlVAF.Validators\CtrlVAF.Validators.csproj">
+      <Project>{3a0d3152-1468-4b0a-8ac7-8ed3322c8602}</Project>
+      <Name>CtrlVAF.Validators</Name>
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />

--- a/CtrlVAF/CtrlVAF.Validators/CtrlVAF.Validators.csproj
+++ b/CtrlVAF/CtrlVAF.Validators/CtrlVAF.Validators.csproj
@@ -1,0 +1,69 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{3A0D3152-1468-4B0A-8AC7-8ED3322C8602}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>CtrlVAF.Validators</RootNamespace>
+    <AssemblyName>CtrlVAF.Validators</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <Deterministic>true</Deterministic>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Interop.MFilesAPI, Version=7.0.0.0, Culture=neutral, PublicKeyToken=f1b4733f444f7ad0, processorArchitecture=MSIL">
+      <HintPath>..\packages\MFiles.VAF.2.1.0.15\lib\net45\Interop.MFilesAPI.dll</HintPath>
+      <EmbedInteropTypes>True</EmbedInteropTypes>
+    </Reference>
+    <Reference Include="MFiles.Crypto, Version=2.1.0.15, Culture=neutral, PublicKeyToken=fa007b370d17fe5e, processorArchitecture=MSIL">
+      <HintPath>..\packages\MFiles.VAF.2.1.0.15\lib\net45\MFiles.Crypto.dll</HintPath>
+    </Reference>
+    <Reference Include="MFiles.VAF, Version=2.1.0.15, Culture=neutral, PublicKeyToken=fa007b370d17fe5e, processorArchitecture=MSIL">
+      <HintPath>..\packages\MFiles.VAF.2.1.0.15\lib\net45\MFiles.VAF.dll</HintPath>
+    </Reference>
+    <Reference Include="MFiles.VAF.Configuration, Version=2.1.0.15, Culture=neutral, PublicKeyToken=fa007b370d17fe5e, processorArchitecture=MSIL">
+      <HintPath>..\packages\MFiles.VAF.2.1.0.15\lib\net45\MFiles.VAF.Configuration.dll</HintPath>
+    </Reference>
+    <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\MFiles.VAF.2.1.0.15\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="CustomValidator.cs" />
+    <Compile Include="Dispatcher.cs" />
+    <Compile Include="ICustomValidator.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/CtrlVAF/CtrlVAF.Validators/CustomValidator.cs
+++ b/CtrlVAF/CtrlVAF.Validators/CustomValidator.cs
@@ -1,0 +1,27 @@
+﻿using MFiles.VAF.Configuration;
+
+using MFilesAPI;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace CtrlVAF.Validators
+{
+    public abstract class CustomValidator<T>: ICustomValidator
+    {
+        public IEnumerable<ValidationFinding> Validate(Vault vault, object configuration)
+        {
+            if (configuration.GetType() != typeof(T))
+                return new ValidationFinding[] { };
+
+            else
+                return Validate(vault, (T)configuration);
+
+        }
+
+        protected abstract IEnumerable<ValidationFinding> Validate(Vault vault, T configuration);
+    }
+}

--- a/CtrlVAF/CtrlVAF.Validators/Dispatcher.cs
+++ b/CtrlVAF/CtrlVAF.Validators/Dispatcher.cs
@@ -1,0 +1,87 @@
+﻿using MFiles.VAF.Configuration;
+
+using MFilesAPI;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace CtrlVAF.Validators
+{
+    public class Dispatcher
+    {
+        public IEnumerable<ValidationFinding> Dispatch(Vault vault, object config)
+        {
+            var callingAssembly = config.GetType().Assembly;
+            var allTypes = callingAssembly.GetTypes();
+
+            Type[] concreteTypes = allTypes.Where(
+                t =>
+                    t.IsClass &&
+                    t.GetInterfaces().Contains(typeof(ICustomValidator))
+                )
+                .ToArray();
+
+            if (!concreteTypes.Any())
+                yield break;
+
+            foreach (Type concreteType in concreteTypes)
+            {
+                //Find config property (or sub-property) matching the generic argument of the basetype
+                Type configSubType = concreteType.BaseType.GenericTypeArguments[0];
+
+                var subConfig = GetConfigPropertyOfType(config, configSubType);
+
+                if (subConfig == null)
+                    continue;
+
+                var concreteHandler = Activator.CreateInstance(concreteType) as ICustomValidator;
+
+                foreach (var finding in concreteHandler.Validate(vault, subConfig))
+                {
+                    yield return finding;
+                }
+            }
+
+        }
+
+        private object GetConfigPropertyOfType(object config, Type configSubType)
+        {
+            if (config.GetType() == configSubType)
+                return config;
+
+            var configProperties = config.GetType().GetProperties();
+
+            foreach (var configProperty in configProperties)
+            {
+                if (!configProperty.PropertyType.IsClass)
+                    continue;
+
+                var subConfig = configProperty.GetValue(config);
+
+                if (configProperty.PropertyType == configSubType)
+                    return subConfig;
+            }
+
+            foreach (var configProperty in configProperties)
+            {
+                if (!configProperty.PropertyType.IsClass)
+                    continue;
+
+                var subConfig = configProperty.GetValue(config);
+
+                var subsubConfig = GetConfigPropertyOfType(subConfig, configSubType);
+                if (subsubConfig == null)
+                    continue;
+                else
+                    return subsubConfig;
+
+            }
+
+            return null;
+        }
+    }
+}

--- a/CtrlVAF/CtrlVAF.Validators/ICustomValidator.cs
+++ b/CtrlVAF/CtrlVAF.Validators/ICustomValidator.cs
@@ -1,0 +1,17 @@
+﻿using MFiles.VAF.Configuration;
+
+using MFilesAPI;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace CtrlVAF.Validators
+{
+    public interface ICustomValidator
+    {
+        IEnumerable<ValidationFinding> Validate(Vault vault, object configuration);
+    }
+}

--- a/CtrlVAF/CtrlVAF.Validators/Properties/AssemblyInfo.cs
+++ b/CtrlVAF/CtrlVAF.Validators/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("CtrlVAF.Validators")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("CtrlVAF.Validators")]
+[assembly: AssemblyCopyright("Copyright ©  2021")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("3a0d3152-1468-4b0a-8ac7-8ed3322c8602")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/CtrlVAF/CtrlVAF.Validators/packages.config
+++ b/CtrlVAF/CtrlVAF.Validators/packages.config
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="MFiles.VAF" version="2.1.0.15" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net45" />
+</packages>

--- a/CtrlVAF/CtrlVAF.sln
+++ b/CtrlVAF/CtrlVAF.sln
@@ -7,6 +7,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CtrlVAF.Commands", "CtrlVAF
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CtrlVAF.Tests", "CtrlVAF.Tests\CtrlVAF.Tests.csproj", "{712CCD24-39EA-4E95-9D3E-DEC7D181AC32}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CtrlVAF.Validators", "CtrlVAF.Validators\CtrlVAF.Validators.csproj", "{3A0D3152-1468-4B0A-8AC7-8ED3322C8602}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -21,6 +23,10 @@ Global
 		{712CCD24-39EA-4E95-9D3E-DEC7D181AC32}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{712CCD24-39EA-4E95-9D3E-DEC7D181AC32}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{712CCD24-39EA-4E95-9D3E-DEC7D181AC32}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3A0D3152-1468-4B0A-8AC7-8ED3322C8602}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3A0D3152-1468-4B0A-8AC7-8ED3322C8602}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3A0D3152-1468-4B0A-8AC7-8ED3322C8602}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3A0D3152-1468-4B0A-8AC7-8ED3322C8602}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
I'm pretty new to Reflection, so there might be various improvements on this.

But I took your idea of a command dispatcher and made a similar thing for custom validation.

It searches for any class that implements CustomValidator<T> and runs a Validate method on them that returns an IEnumerable<ValidationFinding>.

The validator classes do have to be in the same assembly as the Configuration class. I was having trouble with GetCallingAssembly and GetExecutingAssembly, so I solved it that way.

Also I implemented CreateCustomerHandler because the test kept failing and it was bugging me. 😄 