### PR TITLE
Moved ValidationResults cache empty and got rid of lazy loading in va…

### DIFF
--- a/CtrlVAF/CtrlVAF/Core/ConfigurableVaultApplicationBase.cs
+++ b/CtrlVAF/CtrlVAF/Core/ConfigurableVaultApplicationBase.cs
@@ -103,6 +103,8 @@ namespace CtrlVAF.Core
 
         protected override IEnumerable<ValidationFinding> CustomValidation(Vault vault, TSecureConfiguration config)
         {
+            ValidationResults = new ConcurrentDictionary<Type, ValidationResults>();
+
             var command = new ValidationCommand(vault);
 
             var customCommand = AddCustomValidationCommand(vault);
@@ -113,13 +115,6 @@ namespace CtrlVAF.Core
                 return base.CustomValidation(vault, config);
 
             return findings.Concat(base.CustomValidation(vault, config));
-        }
-
-        protected override void OnConfigurationUpdated(IConfigurationRequestContext context, ClientOperations clientOps, TSecureConfiguration oldConfiguration)
-        {
-            ValidationResults = new ConcurrentDictionary<Type, ValidationResults>();
-
-            base.OnConfigurationUpdated(context, clientOps, oldConfiguration);
         }
     }
 }

--- a/CtrlVAF/CtrlVAF/Validation/ValidatorDispatcher.cs
+++ b/CtrlVAF/CtrlVAF/Validation/ValidatorDispatcher.cs
@@ -33,7 +33,7 @@ namespace CtrlVAF.Validation
 
             var types = GetTypes(commands);
 
-            return HandleConcreteTypes(types, commands).ToArray();
+            return HandleConcreteTypes(types, commands);
         }
 
         protected internal override IEnumerable<Type> GetTypes(params ICtrlVAFCommand[] commands)
@@ -74,10 +74,12 @@ namespace CtrlVAF.Validation
         protected internal override IEnumerable<ValidationFinding> HandleConcreteTypes(IEnumerable<Type> concreteValidators, params ICtrlVAFCommand[] commands)
         {
             if (!concreteValidators.Any())
-                yield break;
+                return new ValidationFinding[0];
 
             if (!commands.Any())
-                yield break;
+                return new ValidationFinding[0];
+
+            List<ValidationFinding> findings = new List<ValidationFinding>();
 
             foreach (Type concreteValidatorType in concreteValidators)
             {
@@ -99,13 +101,15 @@ namespace CtrlVAF.Validation
 
                 var validateMethod = concreteValidatorType.GetMethod(nameof(ICustomValidator<object, ValidationCommand>.Validate));
 
-                IEnumerable<ValidationFinding> findings = new ValidationFinding[0];
+                ValidationFinding[] results = new ValidationFinding[0];
 
                 try
                 {
                     var validatorCommand = commands.FirstOrDefault(cmd => cmd.GetType() == concreteValidatorType.BaseType.GenericTypeArguments[1]);
-                    findings = validateMethod.Invoke(concreteHandler, new object[] { validatorCommand })
-                                    as IEnumerable<ValidationFinding>;
+
+                    results = (validateMethod.Invoke(concreteHandler, new object[] { validatorCommand })
+                                    as IEnumerable<ValidationFinding>).ToArray();
+                    findings.AddRange(results);
                 }
                 catch (TargetInvocationException te)
                 {
@@ -116,16 +120,13 @@ namespace CtrlVAF.Validation
                     throw e;
                 }
 
-                if (!vaultApplication.ValidationResults.TryAdd(subConfigType, new ValidationResults(findings)))
+                if (!vaultApplication.ValidationResults.TryAdd(subConfigType, new ValidationResults(results)))
                 {
-                    vaultApplication.ValidationResults[subConfigType].AddResults(findings.ToArray());
-                }
-
-                foreach (var finding in findings)
-                {
-                    yield return finding;
+                    vaultApplication.ValidationResults[subConfigType].AddResults(results);
                 }
             }
+
+            return findings;
         }
     }
 }


### PR DESCRIPTION
I kept running into having some weird situations where the vault reference had been lost because of lazy loading. So I just removed it.
Also moved when the ValidationResults are emptied. They weren't being read by the custom validation anyway. Was also in an awkward situation where they were getting emptied but I needed them before they were refilled.

The order is apparantly:
CustomValidation -> OnConfigurationUpdated -> GetDashboardContent -> CustomValidation.

So I couldn't get the results when trying to access them from GetDashboardContent.