### PR TITLE
Added ConfigurableVaultApplicationBase.AutomaticEventDispatching.cs

### DIFF
--- a/CtrlVAF/CtrlVAF/Core/ConfigurableVaultApplicationBase.AutomaticEventDispatching.cs
+++ b/CtrlVAF/CtrlVAF/Core/ConfigurableVaultApplicationBase.AutomaticEventDispatching.cs
@@ -1,0 +1,134 @@
+﻿using CtrlVAF.Events.Attributes;
+using MFiles.VAF;
+using MFiles.VAF.Common;
+using MFilesAPI;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace CtrlVAF.Core
+{
+	public abstract partial class ConfigurableVaultApplicationBase<TSecureConfiguration>
+		where TSecureConfiguration : class, new()
+	{
+		/// <inheritdoc />
+		protected override void LoadHandlerMethods(Vault vault)
+		{
+			// Use the base implementation in case of old-style registrations.
+			base.LoadHandlerMethods(vault);
+
+			// Identify/register event handlers.
+			try
+			{
+				this.RegisterEventHandlers
+				(
+					this.GetClassesWithAttribute<EventCommandHandlerAttribute>()
+						.SelectMany(kvp => kvp.Value)
+				);
+			}
+			catch(Exception e)
+			{
+				SysUtils.ReportErrorMessageToEventLog("Could not load event handlers", e);
+			}
+		}
+
+		/// <summary>
+		/// Registers the event command 
+		/// </summary>
+		/// <param name="keyValuePair"></param>
+		protected void RegisterEventHandlers
+		(
+			IEnumerable<EventCommandHandlerAttribute> attributes
+		)
+		{
+			// Sanity.
+			attributes = attributes ?? new List<EventCommandHandlerAttribute>();
+
+			// Find the unique types and add event handler method info for each.
+			var eventHandlerInfo = this.CreateEventHandlerMethodInfo();
+			foreach (var eventType in attributes.Select(a => a.MFEvent).Distinct())
+			{
+				// Check if the event type already has a collection.
+				if (!this.eventHandlerMethods.ContainsKey(eventType))
+					this.eventHandlerMethods.Add(eventType, new List<IEventHandlerMethodInfo>());
+
+				// Create the delegate for the event handler method and store it to the collection.
+				this.eventHandlerMethods[eventType].Add(eventHandlerInfo);
+			}
+
+		}
+
+		/// <summary>
+		/// Returns all classes in assemblies provided by <see cref="GetAssembliesForAnalysis"/>
+		/// which have at least one <typeparamref name="T"/> attribute.
+		/// </summary>
+		/// <typeparam name="T">The type of attribute to retrieve.</typeparam>
+		/// <returns>A collection of types that implement the attribute, along with the attributes.</returns>
+		protected Dictionary<Type, List<T>> GetClassesWithAttribute<T>()
+			where T : Attribute
+		{
+			// Create our dictionary of items to process.
+			var dict = new Dictionary<Type, List<T>>();
+
+			// Populate the dictionary with classes that have this type attribute.
+			foreach (var a in this.IncludeAssemblies())
+			{
+				foreach (var c in a.GetTypes().Where(t => t.IsClass && false == t.IsAbstract))
+				{
+					// Get the appropriate attributes (e.g. EventCommandHandlerAttribute).
+					var appropriateAttributes = c.GetCustomAttributes<T>();
+
+					// If this class does not have the attribute then die.
+					if (false == appropriateAttributes.Any())
+						continue;
+					
+					// Add the attributes to our dictionary for further processing.
+					dict.Add(c, appropriateAttributes.ToList());
+				}
+			}
+
+			// Return our classes.
+			return dict;
+		}
+
+		/// <summary>
+		/// Creates an implementation of <see cref="IEventHandlerMethodInfo"/> for routing the event.
+		/// </summary>
+		/// <returns></returns>
+		internal IEventHandlerMethodInfo CreateEventHandlerMethodInfo() => new EventHandlerMethodInfo(this.EventDispatcher);
+
+		internal class EventHandlerMethodInfo : IEventHandlerMethodInfo
+		{
+			public readonly Dispatcher EventDispatcher;
+			public EventHandlerMethodInfo(Dispatcher eventDispatcher)
+			{
+				this.EventDispatcher = eventDispatcher
+					?? throw new ArgumentNullException(nameof(eventDispatcher));
+			}
+
+			#region Implementation of IEventHandlerMethodInfo
+
+			/// <inheritdoc />
+			void IEventHandlerMethodInfo.Execute(MFiles.VAF.Common.EventHandlerEnvironment environment, IExecutionTrace trace)
+			{
+				// Create and dispatch the command.
+				var command = new Events.EventCommand(environment);
+				this.EventDispatcher.Dispatch(command);
+			}
+
+			/// <inheritdoc />
+			// TODO: Implement!
+			string IMethodInfoBase.LogString => "";
+
+			/// <inheritdoc />
+			// TODO: Implement!
+			int IMethodInfoBase.Priority => 0;
+
+			#endregion
+		}
+
+	}
+}

--- a/CtrlVAF/CtrlVAF/Core/ConfigurableVaultApplicationBase.cs
+++ b/CtrlVAF/CtrlVAF/Core/ConfigurableVaultApplicationBase.cs
@@ -44,17 +44,24 @@ namespace CtrlVAF.Core
 
         public virtual Assembly[] IncludeAssemblies()
         {
-            return new Assembly[0];
+            return new Assembly[]
+            {
+                this.GetType().Assembly
+            };
         }
 
-        public override void StartOperations(Vault vaultPersistent)
+
+        public ConfigurableVaultApplicationBase()
         {
             BackgroundDispatcher = new BackgroundDispatcher<TSecureConfiguration>(this);
 
             EventDispatcher = new EventDispatcher<TSecureConfiguration>(this);
 
             ValidatorDispatcher = new ValidatorDispatcher<TSecureConfiguration>(this);
+        }
 
+        public override void StartOperations(Vault vaultPersistent)
+        {
             if (this.GetType().IsDefined(typeof(UseLicensingAttribute)))
             {
                 var content = License?.Content<LicenseContentBase>();

--- a/CtrlVAF/CtrlVAF/CtrlVAF.csproj
+++ b/CtrlVAF/CtrlVAF/CtrlVAF.csproj
@@ -75,6 +75,7 @@
     <Compile Include="BackgroundOperations\Handlers\IBackgroundTaskHandler.cs" />
     <Compile Include="Core\Attributes\LicenseRequiredAttribute.cs" />
     <Compile Include="Core\Attributes\UseLicensingAttribute.cs" />
+    <Compile Include="Core\ConfigurableVaultApplicationBase.AutomaticEventDispatching.cs" />
     <Compile Include="Core\Dispatcher_Common.cs" />
     <Compile Include="Core\ConfigurableVaultApplicationBase.cs" />
     <Compile Include="BackgroundOperations\OnDemandBackgroundOperations.cs" />

--- a/CtrlVAF/CtrlVAF/Events/Attributes/EventCommandHandlerAttribute.cs
+++ b/CtrlVAF/CtrlVAF/Events/Attributes/EventCommandHandlerAttribute.cs
@@ -13,7 +13,7 @@ namespace CtrlVAF.Events.Attributes
     [AttributeUsage(AttributeTargets.Class, AllowMultiple = true, Inherited = false)]
     public class EventCommandHandlerAttribute: Attribute
     {
-        private readonly MFEventHandlerType MFEvent = MFEventHandlerType.MFEventHandlerTypeUndefined;
+        internal readonly MFEventHandlerType MFEvent = MFEventHandlerType.MFEventHandlerTypeUndefined;
 
         public EventCommandHandlerAttribute(MFEventHandlerType MFEvent)
         {


### PR DESCRIPTION
Basic implementation of automatic event dispatching via LoadHandlerMethods.
Note: ConfigurableVaultApplicationBase<T>.CreateEventHandlerMethodInfo should probably instead be exposed via EventDispatcher. Static?
Exposed EventCommandHandlerAttribute.MFEvent so it can be checked (private -> internal).
Moved creation of dispatchers into constructor (so they are available in LoadHandlerMethods).
Exposed the current assembly in InludeAssemblies for ease of use by consumers (no registrations required if one assembly).